### PR TITLE
Avoid starting unnecessary deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+    paths:
+      - '.github/workflows/deploy.yml'
+      - 'LeaveMeAloneGitHubApp/**'
 
 jobs:
   deploy:


### PR DESCRIPTION
If only the `README.md` is changed, for example, which is not even deployed, there is no sense in starting a new workflow run to deploy the Azure Function...

Of course, this here commit touches one of the paths that trigger the deployment, so this will trigger an unnecessary deployment, one last time.