### PR TITLE
Refactor into modules

### DIFF
--- a/LeaveMeAloneGitHubApp/gently.js
+++ b/LeaveMeAloneGitHubApp/gently.js
@@ -1,0 +1,7 @@
+module.exports = (fn, fallback) => {
+    try {
+        return fn()
+    } catch (e) {
+        return fallback
+    }
+}

--- a/LeaveMeAloneGitHubApp/github-api-request-as-app.js
+++ b/LeaveMeAloneGitHubApp/github-api-request-as-app.js
@@ -1,0 +1,43 @@
+module.exports = async (context, appId, requestMethod, requestPath, body) => {
+    const header = {
+        "alg": "RS256",
+        "typ": "JWT"
+    }
+
+    const now = Math.floor(new Date().getTime() / 1000)
+
+    const payload = {
+        // issued at time, 60 seconds in the past to allow for clock drift
+        iat: now - 60,
+        // JWT expiration time (10 minute maximum)
+        exp: now + (10 * 60),
+        // GitHub App's identifier
+        iss: appId
+    }
+
+    const toBase64 = (obj) => Buffer.from(JSON.stringify(obj), "utf-8").toString("base64url")
+	const headerAndPayload = `${toBase64(header)}.${toBase64(payload)}`
+
+    const privateKey = `-----BEGIN RSA PRIVATE KEY-----\n${process.env['GITHUB_APP_PRIVATE_KEY']}\n-----END RSA PRIVATE KEY-----\n`
+
+    const crypto = require('crypto')
+    const signer = crypto.createSign("RSA-SHA256")
+    signer.update(headerAndPayload)
+    const signature = signer.sign({
+        key: privateKey
+    }, "base64url")
+
+    const token = `${headerAndPayload}.${signature}`
+
+    const httpsRequest = require('./https-request')
+    return await httpsRequest(
+        context,
+        null,
+        requestMethod,
+        requestPath,
+        body,
+        {
+            Authorization: `Bearer ${token}`,
+        }
+    )
+}

--- a/LeaveMeAloneGitHubApp/https-request.js
+++ b/LeaveMeAloneGitHubApp/https-request.js
@@ -1,17 +1,19 @@
 module.exports = async (context, requestMethod, requestPath, body, headers) => {
+    headers = {
+        'User-Agent': 'curl/7.68.0',
+        Accept: 'application/json',
+        ...headers || {}
+    }
+    const options = {
+        hostname: 'api.github.com',
+        port: 443,
+        path: requestPath,
+        method: requestMethod || 'GET',
+        headers
+    }
     return new Promise((resolve, reject) => {
         const https = require('https')
-        const request = https.request({
-            host: "api.github.com",
-            port: 443,
-            path: requestPath,
-            method: requestMethod || "GET",
-            headers: {
-                "User-Agent": "curl/7.68.0",
-                Accept: "application/vnd.github+json",
-		...headers
-            }
-        }, (res, e) => {
+        const request = https.request(options, (res, e) => {
             if (e) {
                 reject(e)
                 return

--- a/LeaveMeAloneGitHubApp/https-request.js
+++ b/LeaveMeAloneGitHubApp/https-request.js
@@ -1,3 +1,5 @@
+const gently = require('./gently')
+
 module.exports = async (context, hostname, method, requestPath, body, headers) => {
     headers = {
         'User-Agent': 'LeaveMeAloneGitHubApp/0.0',
@@ -33,7 +35,14 @@ module.exports = async (context, hostname, method, requestPath, body, headers) =
                 res.on('end', () => {
                     const json = Buffer.concat(chunks).toString('utf-8')
                     if (res.statusCode > 299) {
-                        reject(`Got status ${res.statusCode} ${res.statusMessage}\n${json}`)
+                        context.log('FAILED HTTPS request!')
+                        context.log(options)
+                        reject({
+                            statusCode: res.statusCode,
+                            statusMessage: res.statusMessage,
+                            body: json,
+                            json: gently(() => JSON.parse(json))
+                        })
                         return
                     }
                     try {

--- a/LeaveMeAloneGitHubApp/https-request.js
+++ b/LeaveMeAloneGitHubApp/https-request.js
@@ -4,6 +4,11 @@ module.exports = async (context, requestMethod, requestPath, body, headers) => {
         Accept: 'application/json',
         ...headers || {}
     }
+    if (body) {
+        if (typeof body === 'object') body = JSON.stringify(body)
+        headers['Content-Type'] = 'application/json'
+        headers['Content-Length'] = body.length
+    }
     const options = {
         hostname: 'api.github.com',
         port: 443,

--- a/LeaveMeAloneGitHubApp/https-request.js
+++ b/LeaveMeAloneGitHubApp/https-request.js
@@ -1,4 +1,4 @@
-module.exports = async (context, requestMethod, requestPath, body, headers) => {
+module.exports = async (context, method, requestPath, body, headers) => {
     headers = {
         'User-Agent': 'curl/7.68.0',
         Accept: 'application/json',
@@ -12,8 +12,8 @@ module.exports = async (context, requestMethod, requestPath, body, headers) => {
     const options = {
         hostname: 'api.github.com',
         port: 443,
+        method: method || 'GET',
         path: requestPath,
-        method: requestMethod || 'GET',
         headers
     }
     return new Promise((resolve, reject) => {

--- a/LeaveMeAloneGitHubApp/https-request.js
+++ b/LeaveMeAloneGitHubApp/https-request.js
@@ -17,35 +17,39 @@ module.exports = async (context, hostname, method, requestPath, body, headers) =
         headers
     }
     return new Promise((resolve, reject) => {
-        const https = require('https')
-        const request = https.request(options, (res, e) => {
-            if (e) {
-                reject(e)
-                return
-            }
-            context.log(`${requestPath} returned ${res.statusCode}`)
-            context.log(res.headers)
-            res.setEncoding('utf8')
-            var response = ''
-            res.on('data', (chunk) => {
-                response += chunk
-            })
-            res.on('end', () => {
-                if (!response) {
-                    resolve(response)
+        try {
+            const https = require('https')
+            const request = https.request(options, (res, e) => {
+                if (e) {
+                    reject(e)
                     return
                 }
-                try {
-                    resolve(JSON.parse(response))
-                } catch (e) {
+                context.log(`${requestPath} returned ${res.statusCode}`)
+                context.log(res.headers)
+                res.setEncoding('utf8')
+                var response = ''
+                res.on('data', (chunk) => {
+                    response += chunk
+                })
+                res.on('end', () => {
+                    if (!response) {
+                        resolve(response)
+                        return
+                    }
+                    try {
+                        resolve(JSON.parse(response))
+                    } catch (e) {
+                        reject(e)
+                    }
+                })
+                res.on('error', (e) => {
                     reject(e)
-                }
+                })
             })
-            res.on('error', (e) => {
-                reject(e)
-            })
-        })
-        if (body) request.write(body)
-        request.end()
+            if (body) request.write(body)
+            request.end()
+        } catch (e) {
+            reject(e)
+        }
     })
 }

--- a/LeaveMeAloneGitHubApp/https-request.js
+++ b/LeaveMeAloneGitHubApp/https-request.js
@@ -22,20 +22,18 @@ module.exports = async (context, hostname, method, requestPath, body, headers) =
             const req = https.request(options, res => {
                 res.on('error', e => reject(e))
 
-                res.setEncoding('utf8')
-                var response = ''
-                res.on('data', (chunk) => {
-                    response += chunk
-                })
+                const chunks = []
+                res.on('data', data => chunks.push(data))
                 res.on('end', () => {
-                    if (!response) {
-                        resolve(response)
+                    const json = Buffer.concat(chunks).toString('utf-8')
+                    if (res.statusCode > 299) {
+                        reject(`Got status ${res.statusCode} ${res.statusMessage}\n${json}`)
                         return
                     }
                     try {
-                        resolve(JSON.parse(response))
+                        resolve(JSON.parse(json))
                     } catch (e) {
-                        reject(e)
+                        reject(`Invalid JSON: ${json}`)
                     }
                 })
             })

--- a/LeaveMeAloneGitHubApp/https-request.js
+++ b/LeaveMeAloneGitHubApp/https-request.js
@@ -19,7 +19,7 @@ module.exports = async (context, hostname, method, requestPath, body, headers) =
     return new Promise((resolve, reject) => {
         try {
             const https = require('https')
-            const request = https.request(options, (res, e) => {
+            const req = https.request(options, (res, e) => {
                 if (e) {
                     reject(e)
                     return
@@ -46,8 +46,8 @@ module.exports = async (context, hostname, method, requestPath, body, headers) =
                     reject(e)
                 })
             })
-            if (body) request.write(body)
-            request.end()
+            if (body) req.write(body)
+            req.end()
         } catch (e) {
             reject(e)
         }

--- a/LeaveMeAloneGitHubApp/https-request.js
+++ b/LeaveMeAloneGitHubApp/https-request.js
@@ -22,6 +22,12 @@ module.exports = async (context, hostname, method, requestPath, body, headers) =
             const req = https.request(options, res => {
                 res.on('error', e => reject(e))
 
+                if (res.statusCode === 204) resolve({
+                    statusCode: res.statusCode,
+                    statusMessage: res.statusMessage,
+                    headers: res.headers
+                 })
+
                 const chunks = []
                 res.on('data', data => chunks.push(data))
                 res.on('end', () => {

--- a/LeaveMeAloneGitHubApp/https-request.js
+++ b/LeaveMeAloneGitHubApp/https-request.js
@@ -19,11 +19,9 @@ module.exports = async (context, hostname, method, requestPath, body, headers) =
     return new Promise((resolve, reject) => {
         try {
             const https = require('https')
-            const req = https.request(options, (res, e) => {
-                if (e) {
-                    reject(e)
-                    return
-                }
+            const req = https.request(options, res => {
+                res.on('error', e => reject(e))
+
                 context.log(`${requestPath} returned ${res.statusCode}`)
                 context.log(res.headers)
                 res.setEncoding('utf8')
@@ -42,10 +40,8 @@ module.exports = async (context, hostname, method, requestPath, body, headers) =
                         reject(e)
                     }
                 })
-                res.on('error', (e) => {
-                    reject(e)
-                })
             })
+            req.on('error', err => reject(err))
             if (body) req.write(body)
             req.end()
         } catch (e) {

--- a/LeaveMeAloneGitHubApp/https-request.js
+++ b/LeaveMeAloneGitHubApp/https-request.js
@@ -1,4 +1,4 @@
-module.exports = async (context, method, requestPath, body, headers) => {
+module.exports = async (context, hostname, method, requestPath, body, headers) => {
     headers = {
         'User-Agent': 'curl/7.68.0',
         Accept: 'application/json',
@@ -10,8 +10,8 @@ module.exports = async (context, method, requestPath, body, headers) => {
         headers['Content-Length'] = body.length
     }
     const options = {
-        hostname: 'api.github.com',
         port: 443,
+        hostname: hostname || 'api.github.com',
         method: method || 'GET',
         path: requestPath,
         headers

--- a/LeaveMeAloneGitHubApp/https-request.js
+++ b/LeaveMeAloneGitHubApp/https-request.js
@@ -1,6 +1,6 @@
 module.exports = async (context, hostname, method, requestPath, body, headers) => {
     headers = {
-        'User-Agent': 'curl/7.68.0',
+        'User-Agent': 'LeaveMeAloneGitHubApp/0.0',
         Accept: 'application/json',
         ...headers || {}
     }

--- a/LeaveMeAloneGitHubApp/https-request.js
+++ b/LeaveMeAloneGitHubApp/https-request.js
@@ -22,8 +22,6 @@ module.exports = async (context, hostname, method, requestPath, body, headers) =
             const req = https.request(options, res => {
                 res.on('error', e => reject(e))
 
-                context.log(`${requestPath} returned ${res.statusCode}`)
-                context.log(res.headers)
                 res.setEncoding('utf8')
                 var response = ''
                 res.on('data', (chunk) => {

--- a/LeaveMeAloneGitHubApp/index.js
+++ b/LeaveMeAloneGitHubApp/index.js
@@ -28,7 +28,7 @@ const validateGitHubWebHook = (context) => {
 }
 
 /** Sends a JWT-authenticated GitHub API request */
-const sendAuthenticatedGitHubAPIRequest = async (context, appId, requestMethod, requestPath, body) => {
+const gitHubApiRequestAsApp = async (context, appId, requestMethod, requestPath, body) => {
     const header = {
         "alg": "RS256",
         "typ": "JWT"
@@ -115,7 +115,7 @@ module.exports = async function (context, req) {
 
     if (req.headers['x-github-event'] === 'installation' && req.body.action === 'created') {
         try {
-            const res = await sendAuthenticatedGitHubAPIRequest(context, req.body.installation.app_id, 'DELETE', `/app/installations/${req.body.installation.id}`)
+            const res = await gitHubApiRequestAsApp(context, req.body.installation.app_id, 'DELETE', `/app/installations/${req.body.installation.id}`)
             context.log(`Deleted installation ${req.body.installation.id} on ${req.body.repositories.map(e => e.full_name).join(", ")}`)
             context.log(res)
             context.res = {

--- a/LeaveMeAloneGitHubApp/index.js
+++ b/LeaveMeAloneGitHubApp/index.js
@@ -27,48 +27,7 @@ const validateGitHubWebHook = (context) => {
 }
 
 /** Sends a JWT-authenticated GitHub API request */
-const gitHubApiRequestAsApp = async (context, appId, requestMethod, requestPath, body) => {
-    const header = {
-        "alg": "RS256",
-        "typ": "JWT"
-    }
-
-    const now = Math.floor(new Date().getTime() / 1000)
-
-    const payload = {
-        // issued at time, 60 seconds in the past to allow for clock drift
-        iat: now - 60,
-        // JWT expiration time (10 minute maximum)
-        exp: now + (10 * 60),
-        // GitHub App's identifier
-        iss: appId
-    }
-
-    const toBase64 = (obj) => Buffer.from(JSON.stringify(obj), "utf-8").toString("base64url")
-	const headerAndPayload = `${toBase64(header)}.${toBase64(payload)}`
-
-    const privateKey = `-----BEGIN RSA PRIVATE KEY-----\n${process.env['GITHUB_APP_PRIVATE_KEY']}\n-----END RSA PRIVATE KEY-----\n`
-
-    const signer = crypto.createSign("RSA-SHA256")
-    signer.update(headerAndPayload)
-    const signature = signer.sign({
-        key: privateKey
-    }, "base64url")
-
-    const token = `${headerAndPayload}.${signature}`
-
-    const httpsRequest = require('./https-request')
-    return await httpsRequest(
-        context,
-        null,
-        requestMethod,
-        requestPath,
-        body,
-        {
-            Authorization: `Bearer ${token}`,
-        }
-    )
-}
+const gitHubApiRequestAsApp = require('./github-api-request-as-app')
 
 module.exports = async function (context, req) {
     try {

--- a/LeaveMeAloneGitHubApp/index.js
+++ b/LeaveMeAloneGitHubApp/index.js
@@ -60,6 +60,7 @@ const gitHubApiRequestAsApp = async (context, appId, requestMethod, requestPath,
     const httpsRequest = require('./https-request')
     return await httpsRequest(
         context,
+        null,
         requestMethod,
         requestPath,
         body,


### PR DESCRIPTION
Experience shows that it is much easier to debug node.js scripts that can be run from the command-line than it is to debug a full-blown Azure Function. To that end, refactor all the code into Javascript modules that can be easily called from test scripts.